### PR TITLE
Change header encoding from utf16-le to ascii

### DIFF
--- a/avafdict_decode.py
+++ b/avafdict_decode.py
@@ -23,7 +23,7 @@ def decode(inf, outf):
         textblockOffset = struct.unpack("Q", di[HEADER_OFFSETTEXT:HEADER_OFFSETTEXT+8])[0]
         textblockSize = struct.unpack("Q", di[HEADER_SIZEOFTEXT:HEADER_SIZEOFTEXT+8])[0]
 
-        print('format: (' + str(di[0:HEADER_FILECODESIZE].decode("utf-16le")) + ')')
+        print('format: (' + str(di[0:HEADER_FILECODESIZE].decode("ascii")) + ')')
         print('ENTRIES: ' + str(numEntries))
         print('HEADER SIZE: ' + str(headerSize))
         print('DICTIONARY SIZE: ' + str(dictSize))


### PR DESCRIPTION
Any character will be properly encoded without any error. The correct header is still displayed "properly" in the output, and it will highlight corrupted files.